### PR TITLE
chore: remove unnecessary uplink env var

### DIFF
--- a/src/docker_entrypoint.sh
+++ b/src/docker_entrypoint.sh
@@ -1,7 +1,3 @@
 #!/usr/bin/env sh
 
-# use the precomposed supergraph from the uplink instead of the old runtime composition
-# TODO: remove when the uplink is the default
-export APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT=${APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT:-https://uplink.api.apollographql.com/}
-
 node src/index.js


### PR DESCRIPTION
now that it's the default behavior in @apollo/gateway@0.34