### PR TITLE
fix: operation name enforcement

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -225,10 +225,10 @@ function getClientIdentifierEnforcementPlugin(config) {
 function getRequiredOperationNamePlugin(config) {
   if (config === true) {
     return {
-      async requestDidStart({ queryHash, request }) {
+      async requestDidStart({ queryHash }) {
         return {
-          async parsingDidStart() {
-            if (!request.operationName) {
+          async didResolveOperation(requestContext) {
+            if (!requestContext.operationName) {
               throw new ApolloError(
                 "Execution denied: Unnamed operation",
                 "UNNAMED_OPERATION",

--- a/test/operation-names_test.sh
+++ b/test/operation-names_test.sh
@@ -27,7 +27,7 @@ ACTUAL2="$(curl -s http://localhost:4000/graphql \
   -H 'content-type: application/json' \
   -H 'my-client-name: hello' \
   -H 'apollographql-client-version: 1.0' \
-  --data '{"query":"query Test {mission(id: \"1\") { name crew { name } } }", "operationName": "Test"}')"
+  --data '{"query":"query Test {mission(id: \"1\") { name crew { name } } }"}')"
 
 EXPECTED2='{"data":{"mission":{"name":"Mission 1","crew":[{"name":"Astronaut 1"},{"name":"Astronaut 2"},{"name":"Astronaut 3"}]}}}'
 


### PR DESCRIPTION
Previously, the plugin executed too early (before parsing the operation AST) so it wouldn't have access to the operation name from the document — only from the query param.